### PR TITLE
Remove distutils.version's LooseVersion

### DIFF
--- a/libxmp/version.py
+++ b/libxmp/version.py
@@ -36,9 +36,7 @@
 Version information for libxmp.
 """
 
-from distutils.version import LooseVersion
 
 # Do not change the format of this next line!  Doing so risks breaking
 # setup.py
 VERSION = "2.0.1"
-VERSION_TUPLE = LooseVersion(VERSION).version


### PR DESCRIPTION
```bash
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```

Solving https://github.com/python-xmp-toolkit/python-xmp-toolkit/issues/90#issuecomment-1437498726